### PR TITLE
[DAD-435] 로그인 유지

### DIFF
--- a/src/components/molcules/Header.tsx
+++ b/src/components/molcules/Header.tsx
@@ -63,7 +63,7 @@ function Header() {
     }
 
     const userPopOverMenus = [{
-        name: '프로필 수정',
+        name: '프로필 정보',
         link: '/user',
         onClick: hideLoginTooltip,
     }, {

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -3,7 +3,8 @@ import { Navigate, useLocation } from "react-router-dom";
 
 import { USER } from "../config";
 
-const initialUserState: null | object = null;
+const userFromLocalStorage = localStorage.getItem('user');
+const initialUserState: null | object = typeof userFromLocalStorage === 'string' ? JSON.parse(userFromLocalStorage || '') : null;
 
 const userContext = createContext<null | object>(initialUserState);
 
@@ -18,8 +19,10 @@ type Action =
 export function reducer(_state: State, action: Action): any {
     switch (action.type) {
         case 'login':
+            localStorage.setItem('user', JSON.stringify(USER));
             return USER;
         case 'logout':
+            localStorage.removeItem('user');
             return null;
         default:
             return null;


### PR DESCRIPTION
### 개요
DAD-435

### 작업사항
localstorage를 사용하여 유저 정보 저장 및 불러오기 -> 로그인 상태 유지 가능

### 추후 작업해야 할 사항
OAuth local이 아닌 도메인에서도 가능해지면 로그인 기능 뜯어고쳐서 연결...ㅠㅠ
login 관련 hook 분리하는 게 나을 수도 (참고 : [어떤 유튜바의 깃허브](https://github.com/gitdagray/react_protected_routes/blob/main/src/hooks/useAuth.js))